### PR TITLE
remove unnecessary dependency for sensio/framework-extra-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,7 @@
   "require": {
     "php": "^7.2|^8.0",
     "symfony/config": "^4.3.0|^5.0|^6.0",
-    "symfony/dependency-injection": "^4.4.0|^5.0|^6.0",
-    "sensio/framework-extra-bundle": "~3.0|~4.0|~5.0|~6.0"
+    "symfony/dependency-injection": "^4.4.0|^5.0|^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "9.0|^10.1"


### PR DESCRIPTION
## Summary

Remove unused dependency `sensio/framework-extra-bundle` from composer.json.

## Details

After investigating the codebase, I found that `sensio/framework-extra-bundle` was listed as a
dependency in composer.json but was not actually used anywhere in the project:

- No Sensio annotations (@Route, @Method, @Template, @ParamConverter, @Security) found in the codebase
- No imports or usage of Sensio classes detected
- All source files only use standard Symfony components

Additionally, the `sensio/framework-extra-bundle` package has been archived and is now considered obsolete. The functionality it provided has been integrated into Symfony core components in recent versions, making this dependency unnecessary for modern Symfony applications.

## Test plan

- [x] Verify no Sensio annotations are used in the codebase
- [x] Confirm no Sensio classes are imported or referenced
- [x] Check that all existing functionality remains intact